### PR TITLE
added coreosenabled option to create location and test

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10372,6 +10372,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	}
 
 	body := make(map[string]interface{})
+	if createSatelliteLocationOptions.CoreosEnabled {
+		body["coreos_enabled"] = createSatelliteLocationOptions.CoreosEnabled
+	}
 	if createSatelliteLocationOptions.CosConfig != nil {
 		body["cos_config"] = createSatelliteLocationOptions.CosConfig
 	}
@@ -20330,6 +20333,9 @@ func (options *CreateSatelliteClusterRemoteOptions) SetHeaders(param map[string]
 
 // CreateSatelliteLocationOptions : The CreateSatelliteLocation options.
 type CreateSatelliteLocationOptions struct {
+	//Configure whether the location can support CoreOS hosts
+	CoreosEnabled bool
+
 	// COSBucket Optional: IBM Cloud Object Storage bucket configuration details.
 	CosConfig *COSBucket
 
@@ -20365,6 +20371,12 @@ type CreateSatelliteLocationOptions struct {
 // NewCreateSatelliteLocationOptions : Instantiate CreateSatelliteLocationOptions
 func (*KubernetesServiceApiV1) NewCreateSatelliteLocationOptions() *CreateSatelliteLocationOptions {
 	return &CreateSatelliteLocationOptions{}
+}
+
+// SetCoreosEnabled : Allow user to set if the location is CoreOS enabled
+func (options *CreateSatelliteLocationOptions) SetCoreosEnabled(coreosEnabled bool) *CreateSatelliteLocationOptions {
+	options.CoreosEnabled = coreosEnabled
+	return options
 }
 
 // SetCosConfig : Allow user to set CosConfig

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
@@ -25153,6 +25153,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 
 				// Construct an instance of the CreateSatelliteLocationOptions model
 				createSatelliteLocationOptionsModel := new(kubernetesserviceapiv1.CreateSatelliteLocationOptions)
+				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
@@ -25252,6 +25253,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 
 				// Construct an instance of the CreateSatelliteLocationOptions model
 				createSatelliteLocationOptionsModel := new(kubernetesserviceapiv1.CreateSatelliteLocationOptions)
+				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
@@ -25358,6 +25360,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 
 				// Construct an instance of the CreateSatelliteLocationOptions model
 				createSatelliteLocationOptionsModel := new(kubernetesserviceapiv1.CreateSatelliteLocationOptions)
+				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
@@ -25407,6 +25410,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 
 				// Construct an instance of the CreateSatelliteLocationOptions model
 				createSatelliteLocationOptionsModel := new(kubernetesserviceapiv1.CreateSatelliteLocationOptions)
+				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
@@ -41147,6 +41151,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 
 				// Construct an instance of the CreateSatelliteLocationOptions model
 				createSatelliteLocationOptionsModel := kubernetesServiceApiService.NewCreateSatelliteLocationOptions()
+				createSatelliteLocationOptionsModel.SetCoreosEnabled(true)
 				createSatelliteLocationOptionsModel.SetCosConfig(cosBucketModel)
 				createSatelliteLocationOptionsModel.SetCosCredentials(cosAuthorizationModel)
 				createSatelliteLocationOptionsModel.SetDescription("testString")
@@ -41158,6 +41163,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createSatelliteLocationOptionsModel.SetXAuthResourceGroup("testString")
 				createSatelliteLocationOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createSatelliteLocationOptionsModel).ToNot(BeNil())
+				Expect(createSatelliteLocationOptionsModel.CosConfig).To(Equal(true))
 				Expect(createSatelliteLocationOptionsModel.CosConfig).To(Equal(cosBucketModel))
 				Expect(createSatelliteLocationOptionsModel.CosCredentials).To(Equal(cosAuthorizationModel))
 				Expect(createSatelliteLocationOptionsModel.Description).To(Equal(core.StringPtr("testString")))


### PR DESCRIPTION
There is now an option to make a location CoreOS enabled on location create. Adding this field to the go-sdk.

sources: https://containers.cloud.ibm.com/global/swagger-global-api/#/satellite-location
https://cloud.ibm.com/docs/satellite?topic=satellite-locations#locations-create-cli