### PR TITLE
Support for CoreOS Satellite attach script: 

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -28208,6 +28208,9 @@ type MultishiftGetController struct {
 	// CommonClusterCACertRotation CA cert rotation properties.
 	CaCertRotationStatus *CommonClusterCACertRotation `json:"caCertRotationStatus,omitempty"`
 
+	// CoreosEnabled Optional: Enable Red Hat CoreOS features within the Satellite location.
+	CoreosEnabled *bool `json:"coreos_enabled,omitempty"`
+
 	// COSBucket Optional: IBM Cloud Object Storage bucket configuration details.
 	CosConfig *COSBucket `json:"cos_config,omitempty"`
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -16914,6 +16914,9 @@ type AttachSatelliteHostOptions struct {
 	// Key-value pairs to label the host, such as cpu=4 to describe the host capabilities.
 	Labels map[string]string
 
+	//The operating system of the hosts to attach to the location. Options are RHEL or RHCOS
+	OperatingSystem *string
+
 	// The ID of the resource group that the Satellite location is in. To list the resource group ID of the location, use
 	// the `GET /v2/satellite/getController` API method.
 	XAuthResourceGroup *string
@@ -16936,6 +16939,12 @@ func (options *AttachSatelliteHostOptions) SetController(controller string) *Att
 // SetLabels : Allow user to set Labels
 func (options *AttachSatelliteHostOptions) SetLabels(labels map[string]string) *AttachSatelliteHostOptions {
 	options.Labels = labels
+	return options
+}
+
+// SetOperatingSystem : Allow user to set OperatingSystem
+func (options *AttachSatelliteHostOptions) SetOperatingSystem(operatingSystem string) *AttachSatelliteHostOptions {
+	options.OperatingSystem = core.StringPtr(operatingSystem)
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10078,7 +10078,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteAssignmentWit
 }
 
 // AttachSatelliteHost : Attach a host to an IBM Cloud Satellite location
-// Create a script to run on a Red Hat Enterprise Linux 7 host in your on-premises infrastructure. The script attaches
+// Create a script to run on a Red Hat Enterprise Linux 7 or RHCOS (CoreOS) host in your on-premises infrastructure. The script attaches
 // the host to your IBM Cloud Satellite location. The host must have access to the public network in order for the
 // script to complete.
 func (kubernetesServiceApi *KubernetesServiceApiV1) AttachSatelliteHost(attachSatelliteHostOptions *AttachSatelliteHostOptions) (response []byte, err error) {
@@ -10123,6 +10123,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) AttachSatelliteHostWithConte
 	}
 	if attachSatelliteHostOptions.Labels != nil {
 		body["labels"] = attachSatelliteHostOptions.Labels
+	}
+	if attachSatelliteHostOptions.OperatingSystem != nil {
+		body["operatingSystem"] = attachSatelliteHostOptions.OperatingSystem
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -28208,7 +28208,7 @@ type MultishiftGetController struct {
 	// CommonClusterCACertRotation CA cert rotation properties.
 	CaCertRotationStatus *CommonClusterCACertRotation `json:"caCertRotationStatus,omitempty"`
 
-	// CoreosEnabled Optional: Enable Red Hat CoreOS features within the Satellite location.
+	// CoreosEnabled Optional: Returns whether Red Hat CoreOS features are enabled within the Satellite location.
 	CoreosEnabled *bool `json:"coreos_enabled,omitempty"`
 
 	// COSBucket Optional: IBM Cloud Object Storage bucket configuration details.

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -28220,9 +28220,6 @@ type MultishiftGetController struct {
 	// CommonClusterCACertRotation CA cert rotation properties.
 	CaCertRotationStatus *CommonClusterCACertRotation `json:"caCertRotationStatus,omitempty"`
 
-	// CoreosEnabled Optional: Returns whether Red Hat CoreOS features are enabled within the Satellite location.
-	CoreosEnabled *bool `json:"coreos_enabled,omitempty"`
-
 	// COSBucket Optional: IBM Cloud Object Storage bucket configuration details.
 	CosConfig *COSBucket `json:"cos_config,omitempty"`
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
@@ -24583,6 +24583,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				attachSatelliteHostOptionsModel.Labels = make(map[string]string)
 				attachSatelliteHostOptionsModel.XAuthResourceGroup = core.StringPtr("testString")
 				attachSatelliteHostOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				attachSatelliteHostOptionsModel.OperatingSystem = core.StringPtr("RHCOS")
 
 				// Invoke operation with valid options model (positive test)
 				response, operationErr = kubernetesServiceApiService.AttachSatelliteHost(attachSatelliteHostOptionsModel)
@@ -24603,6 +24604,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				attachSatelliteHostOptionsModel.Labels = make(map[string]string)
 				attachSatelliteHostOptionsModel.XAuthResourceGroup = core.StringPtr("testString")
 				attachSatelliteHostOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				attachSatelliteHostOptionsModel.OperatingSystem = core.StringPtr("RHCOS")
 				// Invoke operation with empty URL (negative test)
 				err := kubernetesServiceApiService.SetServiceURL("")
 				Expect(err).To(BeNil())
@@ -40523,11 +40525,13 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				attachSatelliteHostOptionsModel.SetLabels(make(map[string]string))
 				attachSatelliteHostOptionsModel.SetXAuthResourceGroup("testString")
 				attachSatelliteHostOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				attachSatelliteHostOptionsModel.SetOperatingSystem("RHCOS")
 				Expect(attachSatelliteHostOptionsModel).ToNot(BeNil())
 				Expect(attachSatelliteHostOptionsModel.Controller).To(Equal(core.StringPtr("testString")))
 				Expect(attachSatelliteHostOptionsModel.Labels).To(Equal(make(map[string]string)))
 				Expect(attachSatelliteHostOptionsModel.XAuthResourceGroup).To(Equal(core.StringPtr("testString")))
 				Expect(attachSatelliteHostOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+				Expect(attachSatelliteHostOptionsModel.OperatingSystem).To(Equal(core.StringPtr("RHCOS")))
 			})
 			It(`Invoke NewAutoUpdateMasterOptions successfully`, func() {
 				// Construct an instance of the AutoUpdateMasterOptions model


### PR DESCRIPTION
Per requirements here: https://github.com/IBM-Cloud/terraform-provider-ibm/issues/3838

Adding in support for the user to choose RHEL or  RHCOS as the operating system for adding hosts to Satellite location