### PR TITLE
added operatingsystem to workerpool struct

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -26017,6 +26017,8 @@ type GetWorkerPoolResponse struct {
 
 	OpenshiftLicense *string `json:"openshiftLicense,omitempty"`
 
+	OperatingSystem *string `json:"operatingSystem,omitempty"`
+
 	PoolName *string `json:"poolName,omitempty"`
 
 	Provider *string `json:"provider,omitempty"`
@@ -26068,6 +26070,10 @@ func UnmarshalGetWorkerPoolResponse(m map[string]json.RawMessage, result interfa
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "openshiftLicense", &obj.OpenshiftLicense)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "operatingSystem", &obj.OperatingSystem)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In order to update terraform provider https://github.com/IBM-Cloud/terraform-provider-ibm/pull/3990 to support operatingSystem we need to update the worker pool struct in the SDK to have the operatingSystem field.

See return values here: https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/getWorkerPool