### PR TITLE
Fixed Satellite Storage Deprecated Calls

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -11256,7 +11256,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateStorageConfigurationWi
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/storage/satellite/createStorageConfiguration`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/storage/satellite/createStorageConfigurationByController`, nil)
 	if err != nil {
 		return
 	}
@@ -11279,8 +11279,8 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateStorageConfigurationWi
 	if createStorageConfigurationOptions.ConfigVersion != nil {
 		body["config-version"] = createStorageConfigurationOptions.ConfigVersion
 	}
-	if createStorageConfigurationOptions.Location != nil {
-		body["location"] = createStorageConfigurationOptions.Location
+	if createStorageConfigurationOptions.Controller != nil {
+		body["controller"] = createStorageConfigurationOptions.Controller
 	}
 	if createStorageConfigurationOptions.SourceBranch != nil {
 		body["source-branch"] = createStorageConfigurationOptions.SourceBranch
@@ -11322,6 +11322,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateStorageConfigurationWi
 		return
 	}
 	err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalCreateConfigurationData)
+
 	if err != nil {
 		return
 	}
@@ -11697,7 +11698,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) GetStorageConfigurationWithC
 	}
 	builder.AddHeader("Accept", "application/json")
 
-	builder.AddQuery("name", fmt.Sprint(*getStorageConfigurationOptions.Name))
+	builder.AddQuery("config-name", fmt.Sprint(*getStorageConfigurationOptions.Name))
 
 	request, err := builder.Build()
 	if err != nil {
@@ -11986,11 +11987,6 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) RemoveStorageConfigurationWi
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalErrorResponse)
-	if err != nil {
-		return
-	}
-	response.Result = result
 
 	return
 }
@@ -12154,7 +12150,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) UpdateStorageConfigurationWi
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/storage/satellite/updateStorageConfiguration`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/storage/satellite/updateStorageConfigurationByController`, nil)
 	if err != nil {
 		return
 	}
@@ -12177,8 +12173,8 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) UpdateStorageConfigurationWi
 	if updateStorageConfigurationOptions.ConfigVersion != nil {
 		body["config-version"] = updateStorageConfigurationOptions.ConfigVersion
 	}
-	if updateStorageConfigurationOptions.Location != nil {
-		body["location"] = updateStorageConfigurationOptions.Location
+	if updateStorageConfigurationOptions.Controller != nil {
+		body["controller"] = updateStorageConfigurationOptions.Controller
 	}
 	if updateStorageConfigurationOptions.SourceBranch != nil {
 		body["source-branch"] = updateStorageConfigurationOptions.SourceBranch
@@ -12219,11 +12215,6 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) UpdateStorageConfigurationWi
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalErrorResponse)
-	if err != nil {
-		return
-	}
-	response.Result = result
 
 	return
 }
@@ -17780,10 +17771,10 @@ func (options *CleanupMigrationOptions) SetCluster(cluster string) *CleanupMigra
 }
 
 // SetOptions : Allow user to set Options
-// func (options *CleanupMigrationOptions) SetOptions(options []string) *CleanupMigrationOptions {
-// 	options.Options = options
-// 	return options
-// }
+func (options *CleanupMigrationOptions) SetOptions(optionsField []string) *CleanupMigrationOptions {
+	options.Options = optionsField
+	return options
+}
 
 // SetHeaders : Allow user to set Headers
 func (options *CleanupMigrationOptions) SetHeaders(param map[string]string) *CleanupMigrationOptions {
@@ -20723,7 +20714,7 @@ type CreateStorageConfigurationOptions struct {
 
 	ConfigVersion *string
 
-	Location *string
+	Controller *string
 
 	SourceBranch *string
 
@@ -20762,9 +20753,9 @@ func (options *CreateStorageConfigurationOptions) SetConfigVersion(configVersion
 	return options
 }
 
-// SetLocation : Allow user to set Location
-func (options *CreateStorageConfigurationOptions) SetLocation(location string) *CreateStorageConfigurationOptions {
-	options.Location = core.StringPtr(location)
+// SetController : Allow user to set Location
+func (options *CreateStorageConfigurationOptions) SetController(controller string) *CreateStorageConfigurationOptions {
+	options.Controller = core.StringPtr(controller)
 	return options
 }
 
@@ -30960,10 +30951,10 @@ func (options *StartMigrationOptions) SetCluster(cluster string) *StartMigration
 }
 
 // // SetOptions : Allow user to set Options
-// func (options *StartMigrationOptions) SetOptions(options []string) *StartMigrationOptions {
-// 	options.Options = options
-// 	return options
-// }
+func (options *StartMigrationOptions) SetOptions(optionsField []string) *StartMigrationOptions {
+	options.Options = optionsField
+	return options
+}
 
 // SetHeaders : Allow user to set Headers
 func (options *StartMigrationOptions) SetHeaders(param map[string]string) *StartMigrationOptions {
@@ -32625,7 +32616,7 @@ type UpdateStorageConfigurationOptions struct {
 
 	ConfigVersion *string
 
-	Location *string
+	Controller *string
 
 	SourceBranch *string
 
@@ -32664,9 +32655,9 @@ func (options *UpdateStorageConfigurationOptions) SetConfigVersion(configVersion
 	return options
 }
 
-// SetLocation : Allow user to set Location
-func (options *UpdateStorageConfigurationOptions) SetLocation(location string) *UpdateStorageConfigurationOptions {
-	options.Location = core.StringPtr(location)
+// SetController : Allow user to set Location
+func (options *UpdateStorageConfigurationOptions) SetController(controller string) *UpdateStorageConfigurationOptions {
+	options.Controller = core.StringPtr(controller)
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
@@ -27959,7 +27959,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 		})
 	})
 	Describe(`CreateStorageConfiguration(createStorageConfigurationOptions *CreateStorageConfigurationOptions) - Operation response error`, func() {
-		createStorageConfigurationPath := "/v2/storage/satellite/createStorageConfiguration"
+		createStorageConfigurationPath := "/v2/storage/satellite/createStorageConfigurationByController"
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -27985,7 +27985,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.CreateStorageConfigurationOptions)
 				createStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				createStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				createStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -28015,7 +28015,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 	})
 
 	Describe(`CreateStorageConfiguration(createStorageConfigurationOptions *CreateStorageConfigurationOptions)`, func() {
-		createStorageConfigurationPath := "/v2/storage/satellite/createStorageConfiguration"
+		createStorageConfigurationPath := "/v2/storage/satellite/createStorageConfigurationByController"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -28063,7 +28063,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.CreateStorageConfigurationOptions)
 				createStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				createStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				createStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -28148,7 +28148,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.CreateStorageConfigurationOptions)
 				createStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				createStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				createStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -28178,7 +28178,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.CreateStorageConfigurationOptions)
 				createStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				createStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				createStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				createStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -30779,7 +30779,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 		})
 	})
 	Describe(`UpdateStorageConfiguration(updateStorageConfigurationOptions *UpdateStorageConfigurationOptions) - Operation response error`, func() {
-		updateStorageConfigurationPath := "/v2/storage/satellite/updateStorageConfiguration"
+		updateStorageConfigurationPath := "/v2/storage/satellite/updateStorageConfigurationByController"
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -30805,7 +30805,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				updateStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.UpdateStorageConfigurationOptions)
 				updateStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				updateStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				updateStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -30835,7 +30835,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 	})
 
 	Describe(`UpdateStorageConfiguration(updateStorageConfigurationOptions *UpdateStorageConfigurationOptions)`, func() {
-		updateStorageConfigurationPath := "/v2/storage/satellite/updateStorageConfiguration"
+		updateStorageConfigurationPath := "/v2/storage/satellite/updateStorageConfigurationByController"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -30883,7 +30883,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				updateStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.UpdateStorageConfigurationOptions)
 				updateStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				updateStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				updateStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -30968,7 +30968,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				updateStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.UpdateStorageConfigurationOptions)
 				updateStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				updateStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				updateStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -30998,7 +30998,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				updateStorageConfigurationOptionsModel := new(kubernetesserviceapiv1.UpdateStorageConfigurationOptions)
 				updateStorageConfigurationOptionsModel.ConfigName = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.ConfigVersion = core.StringPtr("testString")
-				updateStorageConfigurationOptionsModel.Location = core.StringPtr("testString")
+				updateStorageConfigurationOptionsModel.Controller = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceBranch = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.SourceOrg = core.StringPtr("testString")
 				updateStorageConfigurationOptionsModel.StorageClassParameters = []map[string]string{make(map[string]string)}
@@ -41269,7 +41269,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createStorageConfigurationOptionsModel := kubernetesServiceApiService.NewCreateStorageConfigurationOptions()
 				createStorageConfigurationOptionsModel.SetConfigName("testString")
 				createStorageConfigurationOptionsModel.SetConfigVersion("testString")
-				createStorageConfigurationOptionsModel.SetLocation("testString")
+				createStorageConfigurationOptionsModel.SetController("testString")
 				createStorageConfigurationOptionsModel.SetSourceBranch("testString")
 				createStorageConfigurationOptionsModel.SetSourceOrg("testString")
 				createStorageConfigurationOptionsModel.SetStorageClassParameters([]map[string]string{make(map[string]string)})
@@ -41282,7 +41282,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				Expect(createStorageConfigurationOptionsModel).ToNot(BeNil())
 				Expect(createStorageConfigurationOptionsModel.ConfigName).To(Equal(core.StringPtr("testString")))
 				Expect(createStorageConfigurationOptionsModel.ConfigVersion).To(Equal(core.StringPtr("testString")))
-				Expect(createStorageConfigurationOptionsModel.Location).To(Equal(core.StringPtr("testString")))
+				Expect(createStorageConfigurationOptionsModel.Controller).To(Equal(core.StringPtr("testString")))
 				Expect(createStorageConfigurationOptionsModel.SourceBranch).To(Equal(core.StringPtr("testString")))
 				Expect(createStorageConfigurationOptionsModel.SourceOrg).To(Equal(core.StringPtr("testString")))
 				Expect(createStorageConfigurationOptionsModel.StorageClassParameters).To(Equal([]map[string]string{make(map[string]string)}))
@@ -43582,7 +43582,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				updateStorageConfigurationOptionsModel := kubernetesServiceApiService.NewUpdateStorageConfigurationOptions()
 				updateStorageConfigurationOptionsModel.SetConfigName("testString")
 				updateStorageConfigurationOptionsModel.SetConfigVersion("testString")
-				updateStorageConfigurationOptionsModel.SetLocation("testString")
+				updateStorageConfigurationOptionsModel.SetController("testString")
 				updateStorageConfigurationOptionsModel.SetSourceBranch("testString")
 				updateStorageConfigurationOptionsModel.SetSourceOrg("testString")
 				updateStorageConfigurationOptionsModel.SetStorageClassParameters([]map[string]string{make(map[string]string)})
@@ -43595,7 +43595,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				Expect(updateStorageConfigurationOptionsModel).ToNot(BeNil())
 				Expect(updateStorageConfigurationOptionsModel.ConfigName).To(Equal(core.StringPtr("testString")))
 				Expect(updateStorageConfigurationOptionsModel.ConfigVersion).To(Equal(core.StringPtr("testString")))
-				Expect(updateStorageConfigurationOptionsModel.Location).To(Equal(core.StringPtr("testString")))
+				Expect(updateStorageConfigurationOptionsModel.Controller).To(Equal(core.StringPtr("testString")))
 				Expect(updateStorageConfigurationOptionsModel.SourceBranch).To(Equal(core.StringPtr("testString")))
 				Expect(updateStorageConfigurationOptionsModel.SourceOrg).To(Equal(core.StringPtr("testString")))
 				Expect(updateStorageConfigurationOptionsModel.StorageClassParameters).To(Equal([]map[string]string{make(map[string]string)}))


### PR DESCRIPTION
@bhpratt @hkantare 

The Satellite Storage Configuration API Calls were deprecated, I've updated them for the current development on providing terraform support for Satellite Storage