### PR TITLE
Fixed Satellite Assignment Calls

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -11157,9 +11157,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) GetVolumesWithContext(ctx co
 	return
 }
 
-// CreateAssignment : Create an assignment to a Satellite storage configuration
+// CreateAssignment : Create an assignment using a Satellite storage configuration for the cluster group(s).
 // Create an assignment to install the storage driver that is described by the version of the storage configuration on
-// the cluster group. Then, apps that run in the clusters can use the storage.
+// the cluster group(s). Then, apps that run in the clusters, part of cluster group(s), can use the storage.
 func (kubernetesServiceApi *KubernetesServiceApiV1) CreateAssignment(createAssignmentOptions *CreateAssignmentOptions) (result *CreateSubscriptionData, response *core.DetailedResponse, err error) {
 	return kubernetesServiceApi.CreateAssignmentWithContext(context.Background(), createAssignmentOptions)
 }
@@ -11195,11 +11195,8 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateAssignmentWithContext(
 	builder.AddHeader("Content-Type", "application/json")
 
 	body := make(map[string]interface{})
-	if createAssignmentOptions.ChannelName != nil {
-		body["channelName"] = createAssignmentOptions.ChannelName
-	}
-	if createAssignmentOptions.Cluster != nil {
-		body["cluster"] = createAssignmentOptions.Cluster
+	if createAssignmentOptions.Config != nil {
+		body["config"] = createAssignmentOptions.Config
 	}
 	if createAssignmentOptions.Groups != nil {
 		body["groups"] = createAssignmentOptions.Groups
@@ -11207,8 +11204,79 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateAssignmentWithContext(
 	if createAssignmentOptions.Name != nil {
 		body["name"] = createAssignmentOptions.Name
 	}
-	if createAssignmentOptions.Version != nil {
-		body["version"] = createAssignmentOptions.Version
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = kubernetesServiceApi.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalCreateSubscriptionData)
+	if err != nil {
+		return
+	}
+	response.Result = result
+
+	return
+}
+
+// CreateAssignmentByCluster : Create an assignment using a Satellite storage configuration for a Satellite cluster or service cluster.
+// Create an assignment to install the storage driver described by the version of the storage configuration on
+// the Satellite cluster or service cluster. Then, apps that run in the cluster can use the storage.
+func (kubernetesServiceApi *KubernetesServiceApiV1) CreateAssignmentByCluster(createAssignmentOptions *CreateAssignmentOptions) (result *CreateSubscriptionData, response *core.DetailedResponse, err error) {
+	return kubernetesServiceApi.CreateAssignmentByClusterWithContext(context.Background(), createAssignmentOptions)
+}
+
+// CreateAssignmentWithContext is an alternate form of the CreateAssignment method which supports a Context parameter
+func (kubernetesServiceApi *KubernetesServiceApiV1) CreateAssignmentByClusterWithContext(ctx context.Context, createAssignmentOptions *CreateAssignmentOptions) (result *CreateSubscriptionData, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createAssignmentOptions, "createAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createAssignmentOptions, "createAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/storage/satellite/createAssignmentByCluster`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("kubernetes_service_api", "V1", "CreateAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createAssignmentOptions.Cluster != nil {
+		body["cluster"] = createAssignmentOptions.Cluster
+	}
+	if createAssignmentOptions.Config != nil {
+		body["config"] = createAssignmentOptions.Config
+	}
+	if createAssignmentOptions.Controller != nil {
+		body["controller"] = createAssignmentOptions.Controller
+	}
+	if createAssignmentOptions.Name != nil {
+		body["name"] = createAssignmentOptions.Name
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -12041,6 +12109,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) UpdateAssignmentWithContext(
 	}
 	if updateAssignmentOptions.UUID != nil {
 		body["uuid"] = updateAssignmentOptions.UUID
+	}
+	if updateAssignmentOptions.UpdateConfigVersion != nil {
+		body["updateConfigVersion"] = updateAssignmentOptions.UpdateConfigVersion
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -18932,7 +19003,7 @@ func (options *CreateALBSecretOptions) SetHeaders(param map[string]string) *Crea
 
 // CreateAssignmentOptions : The CreateAssignment options.
 type CreateAssignmentOptions struct {
-	ChannelName *string
+	Config *string
 
 	Cluster *string
 
@@ -18940,7 +19011,7 @@ type CreateAssignmentOptions struct {
 
 	Name *string
 
-	Version *string
+	Controller *string
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -18951,9 +19022,9 @@ func (*KubernetesServiceApiV1) NewCreateAssignmentOptions() *CreateAssignmentOpt
 	return &CreateAssignmentOptions{}
 }
 
-// SetChannelName : Allow user to set ChannelName
-func (options *CreateAssignmentOptions) SetChannelName(channelName string) *CreateAssignmentOptions {
-	options.ChannelName = core.StringPtr(channelName)
+// SetConfig : Allow user to set ConfigName
+func (options *CreateAssignmentOptions) SetConfig(channelName string) *CreateAssignmentOptions {
+	options.Config = core.StringPtr(channelName)
 	return options
 }
 
@@ -18976,8 +19047,8 @@ func (options *CreateAssignmentOptions) SetName(name string) *CreateAssignmentOp
 }
 
 // SetVersion : Allow user to set Version
-func (options *CreateAssignmentOptions) SetVersion(version string) *CreateAssignmentOptions {
-	options.Version = core.StringPtr(version)
+func (options *CreateAssignmentOptions) SetController(controller string) *CreateAssignmentOptions {
+	options.Controller = core.StringPtr(controller)
 	return options
 }
 
@@ -31255,6 +31326,8 @@ type Subscription struct {
 	Version *string `json:"version,omitempty"`
 
 	VersionUUID *string `json:"versionUuid,omitempty"`
+
+	IsAssignmentUpgradeAvailable *bool `json:"isAssignmentUpgradeAvailable,omitempty"`
 }
 
 // UnmarshalSubscription unmarshals an instance of Subscription from the specified map of raw messages.
@@ -31329,6 +31402,10 @@ func UnmarshalSubscription(m map[string]json.RawMessage, result interface{}) (er
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "versionUuid", &obj.VersionUUID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "isAssignmentUpgradeAvailable", &obj.IsAssignmentUpgradeAvailable)
 	if err != nil {
 		return
 	}
@@ -31694,6 +31771,8 @@ type UpdateAssignmentOptions struct {
 
 	UUID *string
 
+	UpdateConfigVersion *bool
+
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
@@ -31718,6 +31797,12 @@ func (options *UpdateAssignmentOptions) SetName(name string) *UpdateAssignmentOp
 // SetUUID : Allow user to set UUID
 func (options *UpdateAssignmentOptions) SetUUID(uuid string) *UpdateAssignmentOptions {
 	options.UUID = core.StringPtr(uuid)
+	return options
+}
+
+// SetUpdateConfigVersion : Allow user to update the config version
+func (options *UpdateAssignmentOptions) SetUpdateConfigVersion(updateConfigVersion bool) *UpdateAssignmentOptions {
+	options.UpdateConfigVersion = core.BoolPtr(updateConfigVersion)
 	return options
 }
 


### PR DESCRIPTION
@bhpratt @hkantare

Added /createAssignmentByCluster and fixed the deprecated parameters for /createAssignment and /updateAssignment