### PR TITLE
add support for reduced firewall satellite attach script

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10090,7 +10090,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteAssignmentWit
 }
 
 // AttachSatelliteHost : Attach a host to an IBM Cloud Satellite location
-// Create a script to run on a Red Hat Enterprise Linux 7 or RHCOS (CoreOS) host in your on-premises infrastructure. The script attaches
+// Create a script to run on a Red Hat Enterprise Linux or RHCOS (CoreOS) host in your on-premises infrastructure. The script attaches
 // the host to your IBM Cloud Satellite location. The host must have access to the public network in order for the
 // script to complete.
 func (kubernetesServiceApi *KubernetesServiceApiV1) AttachSatelliteHost(attachSatelliteHostOptions *AttachSatelliteHostOptions) (response []byte, err error) {
@@ -10138,6 +10138,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) AttachSatelliteHostWithConte
 	}
 	if attachSatelliteHostOptions.OperatingSystem != nil {
 		body["operatingSystem"] = attachSatelliteHostOptions.OperatingSystem
+	}
+	if attachSatelliteHostOptions.HostLinkAgentEndpoint != nil {
+		body["hostLinkAgentEndpoint"] = attachSatelliteHostOptions.HostLinkAgentEndpoint
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -16994,6 +16997,9 @@ type AttachSatelliteHostOptions struct {
 	// The name or ID of the Satellite location.
 	Controller *string
 
+	//Optional: Endpoint for the link agent to use with the reduced firewall attach script.
+	HostLinkAgentEndpoint *string
+
 	// Key-value pairs to label the host, such as cpu=4 to describe the host capabilities.
 	Labels map[string]string
 
@@ -17022,6 +17028,12 @@ func (options *AttachSatelliteHostOptions) SetController(controller string) *Att
 // SetLabels : Allow user to set Labels
 func (options *AttachSatelliteHostOptions) SetLabels(labels map[string]string) *AttachSatelliteHostOptions {
 	options.Labels = labels
+	return options
+}
+
+// SetHostLinkAgentEndpoint : Allow user to set host link endpoint for reduced firewall attach script
+func (options *AttachSatelliteHostOptions) SetHostLinkAgentEndpoint(hostLinkAgentEndpoint string) *AttachSatelliteHostOptions {
+	options.HostLinkAgentEndpoint = core.StringPtr(hostLinkAgentEndpoint)
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
@@ -24592,6 +24592,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				attachSatelliteHostOptionsModel.XAuthResourceGroup = core.StringPtr("testString")
 				attachSatelliteHostOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				attachSatelliteHostOptionsModel.OperatingSystem = core.StringPtr("RHCOS")
+				attachSatelliteHostOptionsModel.HostLinkAgentEndpoint = core.StringPtr("testString")
 
 				// Invoke operation with valid options model (positive test)
 				response, operationErr = kubernetesServiceApiService.AttachSatelliteHost(attachSatelliteHostOptionsModel)
@@ -24613,6 +24614,7 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				attachSatelliteHostOptionsModel.XAuthResourceGroup = core.StringPtr("testString")
 				attachSatelliteHostOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				attachSatelliteHostOptionsModel.OperatingSystem = core.StringPtr("RHCOS")
+				attachSatelliteHostOptionsModel.HostLinkAgentEndpoint = core.StringPtr("testString")
 				// Invoke operation with empty URL (negative test)
 				err := kubernetesServiceApiService.SetServiceURL("")
 				Expect(err).To(BeNil())
@@ -40542,12 +40544,14 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				attachSatelliteHostOptionsModel.SetXAuthResourceGroup("testString")
 				attachSatelliteHostOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				attachSatelliteHostOptionsModel.SetOperatingSystem("RHCOS")
+				attachSatelliteHostOptionsModel.SetHostLinkAgentEndpoint("testString")
 				Expect(attachSatelliteHostOptionsModel).ToNot(BeNil())
 				Expect(attachSatelliteHostOptionsModel.Controller).To(Equal(core.StringPtr("testString")))
 				Expect(attachSatelliteHostOptionsModel.Labels).To(Equal(make(map[string]string)))
 				Expect(attachSatelliteHostOptionsModel.XAuthResourceGroup).To(Equal(core.StringPtr("testString")))
 				Expect(attachSatelliteHostOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 				Expect(attachSatelliteHostOptionsModel.OperatingSystem).To(Equal(core.StringPtr("RHCOS")))
+				Expect(attachSatelliteHostOptionsModel.HostLinkAgentEndpoint).To(Equal(core.StringPtr("testString")))
 			})
 			It(`Invoke NewAutoUpdateMasterOptions successfully`, func() {
 				// Construct an instance of the AutoUpdateMasterOptions model


### PR DESCRIPTION
Satellite has a new feature for reduced firewall requirements: https://cloud.ibm.com/docs/satellite?topic=satellite-coreos-reduced-firewall

Adding this capability to SDK for eventual port to the terraform provider.

Tested locally using these settings for AttachSatelliteHostOptions:

```
	region := map[string]string{"X-Region": "eu-gb"}
	labels := map[string]string{}
	operatingSystem := "RHEL"
	hostLinkAgentEndpoint := "c-01-ws.eu-gb.link.satellite.cloud.ibm.com"
```