### PR TITLE
Adding satellite features, such as custom control plane pod- and service subnet ranges and calico IP autodetection method

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -20216,6 +20216,9 @@ type CreateSatelliteClusterOptions struct {
 
 	// User provided value for single node option.
 	InfrastructureTopology *string
+
+	// The method how the node network interface is selected for the internal pod network.
+    PodNetworkInterfaceSelection map[string]string
 }
 
 // NewCreateSatelliteClusterOptions : Instantiate CreateSatelliteClusterOptions
@@ -20305,6 +20308,13 @@ func (options *CreateSatelliteClusterOptions) SetXAuthResourceGroup(xAuthResourc
 func (options *CreateSatelliteClusterOptions) SetHeaders(param map[string]string) *CreateSatelliteClusterOptions {
 	options.Headers = param
 	return options
+}
+
+
+// SetPodNetworkInterfaceSelection : Allow user to set PodNetworkInterfaceSelection
+func (options *CreateSatelliteClusterOptions) SetPodNetworkInterfaceSelection(podNetworkInterfaceSelection map[string]string) *CreateSatelliteClusterOptions {
+    options.PodNetworkInterfaceSelection = podNetworkInterfaceSelection
+    return options
 }
 
 // CreateSatelliteClusterRemoteOptions : The CreateSatelliteClusterRemote options.
@@ -20483,14 +20493,11 @@ type CreateSatelliteLocationOptions struct {
 	// Allows users to set headers on API requests
 	Headers map[string]string
 
-	// Custom subnet CIDR to provide private IP addresses for pods.
+	// Optional: User provided value for service subnet CIDR to provide private IP addresses for pods.
 	PodSubnet *string
 
-	// Custom subnet CIDR to provide private IP addresses for services.
+	// Optional: User provided value for the pod subnet CIDR to provide private IP addresses for services.
 	ServiceSubnet *string
-
-	// The method how the node network interface is selected for the internal pod network.
-	PodNetworkInterfaceSelection map[string]string
 }
 
 // NewCreateSatelliteLocationOptions : Instantiate CreateSatelliteLocationOptions
@@ -20573,12 +20580,6 @@ func (options *CreateSatelliteLocationOptions) SetPodSubnet(podSubnet string) *C
 // SetServiceSubnet : Allow user to set ServiceSubnet
 func (options *CreateSatelliteLocationOptions) SetServiceSubnet(serviceSubnet string) *CreateSatelliteLocationOptions {
 	options.ServiceSubnet = core.StringPtr(serviceSubnet)
-	return options
-}
-
-// SetPodNetworkInterfaceSelection : Allow user to set PodNetworkInterfaceSelection
-func (options *CreateSatelliteLocationOptions) SetPodNetworkInterfaceSelection(podNetworkInterfaceSelection map[string]string) *CreateSatelliteLocationOptions {
-	options.PodNetworkInterfaceSelection = podNetworkInterfaceSelection
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,7 +10415,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	//if createSatelliteLocationOptions.PodSubnet != nil {
-		body["multishiftPodSubnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
+		body["multishiftPodSubnet"] = "192.168.69.0/24" //createSatelliteLocationOptions.PodSubnet
 	//}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,7 +10415,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	//if createSatelliteLocationOptions.PodSubnet != nil {
-		body["pod_subnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
+		body["pod-subnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
 	//}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,7 +10415,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	if createSatelliteLocationOptions.PodSubnet != nil {
-		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
+		body["pod_subnet"] = createSatelliteLocationOptions.PodSubnet
 	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -20233,9 +20233,6 @@ type CreateSatelliteClusterOptions struct {
 	// User provided value for single node option.
 	InfrastructureTopology *string
 
-	// The method how the node network interface is selected for the internal pod network.
-    PodNetworkInterfaceSelection map[string]string
-
 	// Set IP autodetection to use correct interface for Calico
 	CalicoIPAutodetectionMethods map[string]string
 }

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10414,9 +10414,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	if createSatelliteLocationOptions.PodSubnet != nil {
+	//if createSatelliteLocationOptions.PodSubnet != nil {
 		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
-	}
+	//}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10367,7 +10367,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController/blint`, nil)
 	if err != nil {
 		return
 	}
@@ -10464,7 +10464,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) GetSatelliteLocationWithCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/getController/blint`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/getController`, nil)
 	if err != nil {
 		return
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10414,7 +10414,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	fmt.Println(createSatelliteLocationOptions.PodSubnet)
+	fmt.Printf("kanari: %v", createSatelliteLocationOptions.PodSubnet)
 	if createSatelliteLocationOptions.PodSubnet != nil {
 		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,7 +10415,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	if createSatelliteLocationOptions.PodSubnet != nil {
-		body["pod_subnet"] = createSatelliteLocationOptions.PodSubnet
+		body["pod_subnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
 	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -9763,6 +9763,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteClusterWithCo
 	if createSatelliteClusterOptions.InfrastructureTopology != nil {
 		body["infrastructureTopology"] = createSatelliteClusterOptions.InfrastructureTopology
 	}
+	if createSatelliteClusterOptions.CalicoIPAutodetectionMethods != nil {
+		body["calicoIPAutodetection"] = createSatelliteClusterOptions.CalicoIPAutodetectionMethods
+	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
 		return

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,10 +10415,10 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	if createSatelliteLocationOptions.PodSubnet != nil {
-		body["podSubnet"] = createSatelliteLocationOptions.PodSubnet
+		body["pod_subnet"] = createSatelliteLocationOptions.PodSubnet
 	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
-		body["serviceSubnet"] = createSatelliteLocationOptions.ServiceSubnet
+		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10414,9 +10414,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	if createSatelliteLocationOptions.PodSubnet != nil {
+	//if createSatelliteLocationOptions.PodSubnet != nil {
 		body["pod_subnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
-	}
+	//}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10367,7 +10367,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController/`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController`, nil)
 	if err != nil {
 		return
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,10 +10415,10 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	//if createSatelliteLocationOptions.PodSubnet != nil {
-		body["multishiftPodSubnet"] = "192.168.69.0/24" //createSatelliteLocationOptions.PodSubnet
+		body["multishiftPodSubnet"] = "192.168.0.0/16" //createSatelliteLocationOptions.PodSubnet
 	//}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
-		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet
+		body["multishiftServiceSubnet"] = createSatelliteLocationOptions.ServiceSubnet
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10367,7 +10367,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController/blint`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController/` + string(*createSatelliteLocationOptions.PodSubnet), nil)
 	if err != nil {
 		return
 	}
@@ -10414,7 +10414,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	fmt.Printf("kanari: %v", createSatelliteLocationOptions.PodSubnet)
+	fmt.Printf("canari: %v", createSatelliteLocationOptions.PodSubnet)
 	if createSatelliteLocationOptions.PodSubnet != nil {
 		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10367,9 +10367,6 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		return
 	}
 
-	fmt.Println("canari sdk create satellite location before api call")
-	fmt.Println(createSatelliteLocationOptions)
-
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
@@ -10422,13 +10419,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	}
 	if createSatelliteLocationOptions.PodSubnet != nil {
 		body["multishiftPodSubnet"] = createSatelliteLocationOptions.PodSubnet
-	} else {
-		fmt.Println("canari sdk podsubnet is nil :/")
 	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["multishiftServiceSubnet"] = createSatelliteLocationOptions.ServiceSubnet
-	} else {
-		fmt.Println("canari sdk servicesubnet is nil :/")
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10464,7 +10464,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) GetSatelliteLocationWithCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/getController`, nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/getController/blint`, nil)
 	if err != nil {
 		return
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -20488,6 +20488,9 @@ type CreateSatelliteLocationOptions struct {
 
 	// Custom subnet CIDR to provide private IP addresses for services.
 	ServiceSubnet *string
+
+	// The method how the node network interface is selected for the internal pod network.
+	PodNetworkInterfaceSelection map[string]string
 }
 
 // NewCreateSatelliteLocationOptions : Instantiate CreateSatelliteLocationOptions
@@ -20570,6 +20573,12 @@ func (options *CreateSatelliteLocationOptions) SetPodSubnet(podSubnet string) *C
 // SetServiceSubnet : Allow user to set ServiceSubnet
 func (options *CreateSatelliteLocationOptions) SetServiceSubnet(serviceSubnet string) *CreateSatelliteLocationOptions {
 	options.ServiceSubnet = core.StringPtr(serviceSubnet)
+	return options
+}
+
+// SetPodNetworkInterfaceSelection : Allow user to set PodNetworkInterfaceSelection
+func (options *CreateSatelliteLocationOptions) SetPodNetworkInterfaceSelection(podNetworkInterfaceSelection map[string]string) *CreateSatelliteLocationOptions {
+	options.PodNetworkInterfaceSelection = podNetworkInterfaceSelection
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,7 +10415,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	//if createSatelliteLocationOptions.PodSubnet != nil {
-		body["pod-subnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
+		body["multishiftPodSubnet"] = "192.168.69.0/16" //createSatelliteLocationOptions.PodSubnet
 	//}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10364,6 +10364,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		return
 	}
 
+	fmt.Println("canari sdk create satellite location before api call")
+	fmt.Println(createSatelliteLocationOptions)
+
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
@@ -10414,11 +10417,15 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	//if createSatelliteLocationOptions.PodSubnet != nil {
-		body["multishiftPodSubnet"] = "192.168.0.0/16" //createSatelliteLocationOptions.PodSubnet
-	//}
+	if createSatelliteLocationOptions.PodSubnet != nil {
+		body["multishiftPodSubnet"] = createSatelliteLocationOptions.PodSubnet
+	} else {
+		fmt.Println("canari sdk podsubnet is nil :/")
+	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["multishiftServiceSubnet"] = createSatelliteLocationOptions.ServiceSubnet
+	} else {
+		fmt.Println("canari sdk servicesubnet is nil :/")
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -20482,6 +20482,12 @@ type CreateSatelliteLocationOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// Custom subnet CIDR to provide private IP addresses for pods.
+	PodSubnet *string
+
+	// Custom subnet CIDR to provide private IP addresses for services.
+	ServiceSubnet *string
 }
 
 // NewCreateSatelliteLocationOptions : Instantiate CreateSatelliteLocationOptions
@@ -20552,6 +20558,18 @@ func (options *CreateSatelliteLocationOptions) SetXAuthResourceGroup(xAuthResour
 // SetHeaders : Allow user to set Headers
 func (options *CreateSatelliteLocationOptions) SetHeaders(param map[string]string) *CreateSatelliteLocationOptions {
 	options.Headers = param
+	return options
+}
+
+// SetPodSubnet : Allow user to set PodSubnet
+func (options *CreateSatelliteLocationOptions) SetPodSubnet(podSubnet string) *CreateSatelliteLocationOptions {
+	options.PodSubnet = core.StringPtr(podSubnet)
+	return options
+}
+
+// SetServiceSubnet : Allow user to set ServiceSubnet
+func (options *CreateSatelliteLocationOptions) SetServiceSubnet(serviceSubnet string) *CreateSatelliteLocationOptions {
+	options.ServiceSubnet = core.StringPtr(serviceSubnet)
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -20232,6 +20232,9 @@ type CreateSatelliteClusterOptions struct {
 
 	// The method how the node network interface is selected for the internal pod network.
     PodNetworkInterfaceSelection map[string]string
+
+	// Set IP autodetection to use correct interface for Calico
+	CalicoIPAutodetectionMethods map[string]string
 }
 
 // NewCreateSatelliteClusterOptions : Instantiate CreateSatelliteClusterOptions
@@ -20328,6 +20331,12 @@ func (options *CreateSatelliteClusterOptions) SetHeaders(param map[string]string
 func (options *CreateSatelliteClusterOptions) SetPodNetworkInterfaceSelection(podNetworkInterfaceSelection map[string]string) *CreateSatelliteClusterOptions {
     options.PodNetworkInterfaceSelection = podNetworkInterfaceSelection
     return options
+}
+
+// SetCalicoIPAutodetectionMethods : Set IP autodetection to use correct interface for Calico
+func (options *CreateSatelliteClusterOptions) SetCalicoIPAutodetectionMethods(calicoIPAutodetectionMethods map[string]string) *CreateSatelliteClusterOptions {
+	options.CalicoIPAutodetectionMethods = calicoIPAutodetectionMethods
+	return options
 }
 
 // CreateSatelliteClusterRemoteOptions : The CreateSatelliteClusterRemote options.

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10414,9 +10414,10 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	//if createSatelliteLocationOptions.PodSubnet != nil {
+	fmt.Println(createSatelliteLocationOptions.PodSubnet)
+	if createSatelliteLocationOptions.PodSubnet != nil {
 		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
-	//}
+	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10414,6 +10414,12 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
+	if createSatelliteLocationOptions.PodSubnet != nil {
+		body["podSubnet"] = createSatelliteLocationOptions.PodSubnet
+	}
+	if createSatelliteLocationOptions.ServiceSubnet != nil {
+		body["serviceSubnet"] = createSatelliteLocationOptions.ServiceSubnet
+	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
 		return

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10415,7 +10415,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
 	if createSatelliteLocationOptions.PodSubnet != nil {
-		body["pod_subnet"] = createSatelliteLocationOptions.PodSubnet
+		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
 	}
 	if createSatelliteLocationOptions.ServiceSubnet != nil {
 		body["service_subnet"] = createSatelliteLocationOptions.ServiceSubnet

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -10367,7 +10367,7 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = kubernetesServiceApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController/` + string(*createSatelliteLocationOptions.PodSubnet), nil)
+	_, err = builder.ResolveRequestURL(kubernetesServiceApi.Service.Options.URL, `/v2/satellite/createController/`, nil)
 	if err != nil {
 		return
 	}
@@ -10414,7 +10414,6 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Zones != nil {
 		body["zones"] = createSatelliteLocationOptions.Zones
 	}
-	fmt.Printf("canari: %v", createSatelliteLocationOptions.PodSubnet)
 	if createSatelliteLocationOptions.PodSubnet != nil {
 		body["pod_subnet"] = "192.168.69.0/16"  //createSatelliteLocationOptions.PodSubnet
 	}


### PR DESCRIPTION
Satellite has feature that allows customer to set the multishift cluster's pod- and service subnets, described here: https://cloud.ibm.com/docs/openshift?topic=openshift-satellite-network-customization#sat-network-custom-subnet

The other feature is that customer could set the satellite cluster's Calico IP autodetection method: https://docs.tigera.io/calico/latest/reference/configure-calico-node#ip-autodetection-methods