### PR TITLE
Satellite Storage Assignment and Configuration fix

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -12003,19 +12003,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) RemoveAssignmentWithContext(
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
-	builder.AddHeader("Content-Type", "application/json")
 
-	body := make(map[string]interface{})
-	if removeAssignmentOptions.UUID != nil {
-		body["uuid"] = *removeAssignmentOptions.UUID
-	}
-	if removeAssignmentOptions.Controller != nil {
-		body["controller"] = *removeAssignmentOptions.Controller
-	}
-	_, err = builder.SetBodyContentJSON(body)
-	if err != nil {
-		return
-	}
+	builder.AddQuery("uuid", fmt.Sprint(*removeAssignmentOptions.UUID))
+	builder.AddQuery("controller", fmt.Sprint(*removeAssignmentOptions.Controller))
 
 	request, err := builder.Build()
 	if err != nil {
@@ -12074,6 +12064,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) RemoveStorageConfigurationWi
 
 	builder.AddQuery("uuid", fmt.Sprint(*removeStorageConfigurationOptions.UUID))
 	builder.AddQuery("controller", fmt.Sprint(*removeStorageConfigurationOptions.Controller))
+	if removeStorageConfigurationOptions.RemoveAssignments != nil {
+		builder.AddQuery("removeAssignments", fmt.Sprint(*removeStorageConfigurationOptions.RemoveAssignments))
+	}
 
 	request, err := builder.Build()
 	if err != nil {
@@ -29897,6 +29890,7 @@ type RemoveAssignmentOptions struct {
 	// ls`.
 	UUID *string `json:"uuid,omitempty"`
 
+	// The name or ID of the Satellite location. To list the Satellite locations that you have access to, run `ibmcloud sat location ls`
 	Controller *string `json:"controller,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -29913,6 +29907,12 @@ func (*KubernetesServiceApiV1) NewRemoveAssignmentOptions(uuid string) *RemoveAs
 // SetUUID : Allow user to set UUID
 func (options *RemoveAssignmentOptions) SetUUID(uuid string) *RemoveAssignmentOptions {
 	options.UUID = core.StringPtr(uuid)
+	return options
+}
+
+// SetController : Allow user to set the Controller
+func (options *RemoveAssignmentOptions) SetController(controller string) *RemoveAssignmentOptions {
+	options.Controller = core.StringPtr(controller)
 	return options
 }
 
@@ -30380,7 +30380,11 @@ type RemoveStorageConfigurationOptions struct {
 	// configuration UUID, run `ibmcloud sat config get --config=<storage-configuration-name>`.
 	UUID *string `json:"uuid,omitempty"`
 
+	// The name or ID of the Satellite location. To list the Satellite locations that you have access to, run `ibmcloud sat location ls`
 	Controller *string `json:"controller,omitempty"`
+
+	// Specify true to remove the storage configuration along with the associated assignments. If unspecified, the default value is false.
+	RemoveAssignments *bool `json:"removeAssignments,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -30396,6 +30400,18 @@ func (*KubernetesServiceApiV1) NewRemoveStorageConfigurationOptions(uuid string)
 // SetUUID : Allow user to set UUID
 func (options *RemoveStorageConfigurationOptions) SetUUID(uuid string) *RemoveStorageConfigurationOptions {
 	options.UUID = core.StringPtr(uuid)
+	return options
+}
+
+// SetController : Allow user to set the Controller/Location
+func (options *RemoveStorageConfigurationOptions) SetController(controller string) *RemoveStorageConfigurationOptions {
+	options.Controller = core.StringPtr(controller)
+	return options
+}
+
+// SetController : Allow user to set the Controller/Location
+func (options *RemoveStorageConfigurationOptions) SetRemoveAssignments(removeAssignments bool) *RemoveStorageConfigurationOptions {
+	options.RemoveAssignments = core.BoolPtr(removeAssignments)
 	return options
 }
 

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -11222,6 +11222,9 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateAssignmentWithContext(
 	if createAssignmentOptions.Name != nil {
 		body["name"] = createAssignmentOptions.Name
 	}
+	if createAssignmentOptions.Controller != nil {
+		body["controller"] = createAssignmentOptions.Controller
+	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
 		return

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -12003,8 +12003,19 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) RemoveAssignmentWithContext(
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
 
-	builder.AddQuery("uuid", fmt.Sprint(*removeAssignmentOptions.UUID))
+	body := make(map[string]interface{})
+	if removeAssignmentOptions.UUID != nil {
+		body["uuid"] = *removeAssignmentOptions.UUID
+	}
+	if removeAssignmentOptions.Controller != nil {
+		body["controller"] = *removeAssignmentOptions.Controller
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
 
 	request, err := builder.Build()
 	if err != nil {
@@ -12060,9 +12071,19 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) RemoveStorageConfigurationWi
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
 
-	builder.AddQuery("uuid", fmt.Sprint(*removeStorageConfigurationOptions.UUID))
-
+	body := make(map[string]interface{})
+	if removeStorageConfigurationOptions.UUID != nil {
+		body["uuid"] = *removeStorageConfigurationOptions.UUID
+	}
+	if removeStorageConfigurationOptions.Controller != nil {
+		body["controller"] = *removeStorageConfigurationOptions.Controller
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
 	request, err := builder.Build()
 	if err != nil {
 		return
@@ -29883,7 +29904,9 @@ func UnmarshalRemoteResourcesSearchableData(m map[string]json.RawMessage, result
 type RemoveAssignmentOptions struct {
 	// The UUID of the assignment. To list the assignments that you have access to, run `ibmcloud sat storage assignment
 	// ls`.
-	UUID *string `validate:"required"`
+	UUID *string `json:"uuid,omitempty"`
+
+	Controller *string `json:"controller,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -30364,7 +30387,9 @@ type RemoveStorageConfigurationOptions struct {
 	// The UUID of the storage configuration. To list the storage configurations that you have access to, run `ibmcloud sat
 	// storage config ls`. To view the storage assignments associated with a given storage configuration and the storage
 	// configuration UUID, run `ibmcloud sat config get --config=<storage-configuration-name>`.
-	UUID *string `validate:"required"`
+	UUID *string `json:"uuid,omitempty"`
+
+	Controller *string `json:"controller,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -30409,7 +30409,7 @@ func (options *RemoveStorageConfigurationOptions) SetController(controller strin
 	return options
 }
 
-// SetController : Allow user to set the Controller/Location
+// SetRemoveAssignments : Specify true to remove the storage configuration along with the associated assignments.
 func (options *RemoveStorageConfigurationOptions) SetRemoveAssignments(removeAssignments bool) *RemoveStorageConfigurationOptions {
 	options.RemoveAssignments = core.BoolPtr(removeAssignments)
 	return options

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -12071,19 +12071,10 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) RemoveStorageConfigurationWi
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
-	builder.AddHeader("Content-Type", "application/json")
 
-	body := make(map[string]interface{})
-	if removeStorageConfigurationOptions.UUID != nil {
-		body["uuid"] = *removeStorageConfigurationOptions.UUID
-	}
-	if removeStorageConfigurationOptions.Controller != nil {
-		body["controller"] = *removeStorageConfigurationOptions.Controller
-	}
-	_, err = builder.SetBodyContentJSON(body)
-	if err != nil {
-		return
-	}
+	builder.AddQuery("uuid", fmt.Sprint(*removeStorageConfigurationOptions.UUID))
+	builder.AddQuery("controller", fmt.Sprint(*removeStorageConfigurationOptions.Controller))
+
 	request, err := builder.Build()
 	if err != nil {
 		return


### PR DESCRIPTION
The `controller` parameter has been added to the following calls - 

- /removeAssignment
- /removeStorageConfiguration
- /createAssignment 