### PR TITLE
Add PhysicalAddress and CapabilitiesManagedBySatellite to SatelliteLocation API

### DIFF
--- a/kubernetesserviceapiv1/kubernetes_service_api_v1.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/IBM-Cloud/container-services-go-sdk/common"
 	"github.com/IBM/go-sdk-core/v5/core"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/common"
 )
 
 // KubernetesServiceApiV1 : With IBM Cloud Kubernetes Service, you can deploy highly available apps in containers that
@@ -10408,6 +10409,12 @@ func (kubernetesServiceApi *KubernetesServiceApiV1) CreateSatelliteLocationWithC
 	if createSatelliteLocationOptions.Description != nil {
 		body["description"] = createSatelliteLocationOptions.Description
 	}
+	if createSatelliteLocationOptions.PhysicalAddress != nil {
+		body["physicalAddress"] = createSatelliteLocationOptions.PhysicalAddress
+	}
+	if createSatelliteLocationOptions.CapabilitiesManagedBySatellite != nil {
+		body["capabilitiesManagedBySatellite"] = createSatelliteLocationOptions.CapabilitiesManagedBySatellite
+	}
 	if createSatelliteLocationOptions.Iaas != nil {
 		body["iaas"] = createSatelliteLocationOptions.Iaas
 	}
@@ -17337,6 +17344,15 @@ func UnmarshalBoundService(m map[string]json.RawMessage, result interface{}) (er
 	return
 }
 
+// CapabilityManagedBySatellite is a custom type for satellite capabilities
+type CapabilityManagedBySatellite string
+
+// Supported satellite capabilities
+const (
+	//OnPrem indicates that the location is on the premises of the customer
+	OnPrem CapabilityManagedBySatellite = "on-prem"
+)
+
 // COSAuthorization : COSAuthorization Optional: IBM Cloud Object Storage authorization keys.
 type COSAuthorization struct {
 	// The HMAC secret access key ID.
@@ -20524,6 +20540,12 @@ type CreateSatelliteLocationOptions struct {
 	// A description of the new Satellite location.
 	Description *string
 
+	// An optional physical address of the new Satellite location which is deployed on premise
+	PhysicalAddress *string
+
+	//Satellite capabilities attached to the satellite location
+	CapabilitiesManagedBySatellite []CapabilityManagedBySatellite
+
 	Iaas *IAAS
 
 	// The IBM Cloud metro from which the Satellite location is managed.
@@ -20579,6 +20601,18 @@ func (options *CreateSatelliteLocationOptions) SetCosCredentials(cosCredentials 
 // SetDescription : Allow user to set Description
 func (options *CreateSatelliteLocationOptions) SetDescription(description string) *CreateSatelliteLocationOptions {
 	options.Description = core.StringPtr(description)
+	return options
+}
+
+// SetPhysicalAddress : Allow user to set PhysicalAddress
+func (options *CreateSatelliteLocationOptions) SetPhysicalAddress(physicalAddress string) *CreateSatelliteLocationOptions {
+	options.PhysicalAddress = core.StringPtr(physicalAddress)
+	return options
+}
+
+// SetCapabilitiesManagedBySatellite : Allow user to set CapabilitiesManagedBySatellite
+func (options *CreateSatelliteLocationOptions) SetCapabilities(capabilitiesManagedBySatellite []CapabilityManagedBySatellite) *CreateSatelliteLocationOptions {
+	options.CapabilitiesManagedBySatellite = capabilitiesManagedBySatellite
 	return options
 }
 
@@ -28282,6 +28316,9 @@ type MultishiftController struct {
 	// Deployments reports status of deployments on the IBM Cloud Satellite location.
 	Deployments *Deployments `json:"deployments,omitempty"`
 
+	//CapabilitiesManagedBySatellite attached to the satellite location
+	CapabilitiesManagedBySatellite []CapabilityManagedBySatellite
+
 	// Hosts lists the hosts belonging to the IBM Cloud Satellite location.
 	Hosts *Hosts `json:"hosts,omitempty"`
 
@@ -28324,6 +28361,10 @@ func UnmarshalMultishiftController(m map[string]json.RawMessage, result interfac
 		return
 	}
 	err = core.UnmarshalModel(m, "deployments", &obj.Deployments, UnmarshalDeployments)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "capabilitiesManagedBySatellite", &obj.CapabilitiesManagedBySatellite)
 	if err != nil {
 		return
 	}
@@ -28455,6 +28496,12 @@ type MultishiftGetController struct {
 
 	Description *string `json:"description,omitempty"`
 
+	// An optional physical address of the new Satellite location which is deployed on premise
+	PhysicalAddress *string `json:"physicalAddress,omitempty"`
+
+	//Satellite capabilities attached to the satellite location
+	CapabilitiesManagedBySatellite []CapabilityManagedBySatellite
+
 	DisableAutoUpdate *bool `json:"disableAutoUpdate,omitempty"`
 
 	Entitlement *string `json:"entitlement,omitempty"`
@@ -28555,7 +28602,15 @@ func UnmarshalMultishiftGetController(m map[string]json.RawMessage, result inter
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "capabilitiesManagedBySatellite", &obj.CapabilitiesManagedBySatellite)
+	if err != nil {
+		return
+	}
 	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "physicalAddress", &obj.PhysicalAddress)
 	if err != nil {
 		return
 	}

--- a/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
+++ b/kubernetesserviceapiv1/kubernetes_service_api_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1"
 )
 
 var _ = Describe(`KubernetesServiceApiV1`, func() {
@@ -25168,7 +25169,9 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
+				createSatelliteLocationOptionsModel.PhysicalAddress = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
+				createSatelliteLocationOptionsModel.CapabilitiesManagedBySatellite = []kubernetesserviceapiv1.CapabilityManagedBySatellite{kubernetesserviceapiv1.OnPrem}
 				createSatelliteLocationOptionsModel.Iaas = iaasModel
 				createSatelliteLocationOptionsModel.Location = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.LoggingAccountID = core.StringPtr("testString")
@@ -25268,7 +25271,9 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
+				createSatelliteLocationOptionsModel.PhysicalAddress = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
+				createSatelliteLocationOptionsModel.CapabilitiesManagedBySatellite = []kubernetesserviceapiv1.CapabilityManagedBySatellite{kubernetesserviceapiv1.OnPrem}
 				createSatelliteLocationOptionsModel.Iaas = iaasModel
 				createSatelliteLocationOptionsModel.Location = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.LoggingAccountID = core.StringPtr("testString")
@@ -25375,7 +25380,9 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
+				createSatelliteLocationOptionsModel.PhysicalAddress = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
+				createSatelliteLocationOptionsModel.CapabilitiesManagedBySatellite = []kubernetesserviceapiv1.CapabilityManagedBySatellite{kubernetesserviceapiv1.OnPrem}
 				createSatelliteLocationOptionsModel.Iaas = iaasModel
 				createSatelliteLocationOptionsModel.Location = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.LoggingAccountID = core.StringPtr("testString")
@@ -25425,7 +25432,9 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createSatelliteLocationOptionsModel.CoreosEnabled = true
 				createSatelliteLocationOptionsModel.CosConfig = cosBucketModel
 				createSatelliteLocationOptionsModel.CosCredentials = cosAuthorizationModel
+				createSatelliteLocationOptionsModel.PhysicalAddress = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.Description = core.StringPtr("testString")
+				createSatelliteLocationOptionsModel.CapabilitiesManagedBySatellite = []kubernetesserviceapiv1.CapabilityManagedBySatellite{kubernetesserviceapiv1.OnPrem}
 				createSatelliteLocationOptionsModel.Iaas = iaasModel
 				createSatelliteLocationOptionsModel.Location = core.StringPtr("testString")
 				createSatelliteLocationOptionsModel.LoggingAccountID = core.StringPtr("testString")
@@ -41175,7 +41184,6 @@ var _ = Describe(`KubernetesServiceApiV1`, func() {
 				createSatelliteLocationOptionsModel.SetXAuthResourceGroup("testString")
 				createSatelliteLocationOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createSatelliteLocationOptionsModel).ToNot(BeNil())
-				Expect(createSatelliteLocationOptionsModel.CosConfig).To(Equal(true))
 				Expect(createSatelliteLocationOptionsModel.CosConfig).To(Equal(cosBucketModel))
 				Expect(createSatelliteLocationOptionsModel.CosCredentials).To(Equal(cosAuthorizationModel))
 				Expect(createSatelliteLocationOptionsModel.Description).To(Equal(core.StringPtr("testString")))


### PR DESCRIPTION
PhysicalAddress and CapabilitiesManagedBySatellite have been added as new parameters to [SatelliteLocationAPIs](https://cloud.ibm.com/apidocs/kubernetes/containers-v1-v2#createsatellitelocation) already. Here, Address has been added to Create and Get APIs, whereas Capabilities has been added to Create, Get and List APIs.

Therefore, I would like to submit this Pull-Request, in order to add Address and Capabilities respectively in the SatelliteLocation methods of IBM-Cloud/container-services-go-sdk/kubernetesserviceapiv1, so that it can be used to extend SatelliteLocation functionality in [terraform-provider-ibm](https://github.com/IBM-Cloud/terraform-provider-ibm).